### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/react/LanguagesSelector.tsx
+++ b/src/components/react/LanguagesSelector.tsx
@@ -9,6 +9,13 @@ export default function LanguageSelector() {
 
 	const handleLanguageChange = (event: { target: { value: any } }) => {
 		const selectedLanguageCode = event.target.value;
+		
+		// Validate the selected language code
+		if (!Object.keys(languages).includes(selectedLanguageCode)) {
+			console.warn(`Invalid language code: ${selectedLanguageCode}`);
+			return; // Exit the function if the value is invalid
+		}
+
 		const currentPathname = url.pathname;
 		const currentHash = url.hash;
 		// some big ball regex skill flexing there :D


### PR DESCRIPTION
Potential fix for [https://github.com/Sir-Thom/thomastoulouse.ca/security/code-scanning/5](https://github.com/Sir-Thom/thomastoulouse.ca/security/code-scanning/5)

To fix the issue, we need to validate and sanitize the `selectedLanguageCode` before using it to construct the `newPathname`. This can be achieved by ensuring that the `selectedLanguageCode` matches one of the predefined keys in the `languages` object. If the value is invalid, we can either reject it or default to a safe fallback value. This approach ensures that only trusted values are used in the URL construction.

Changes to be made:
1. Add a validation step to check if `selectedLanguageCode` exists in the `languages` object.
2. If the value is invalid, default to the current language or another safe value.
3. Update the `handleLanguageChange` function to include this validation logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
