### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main, maste,Dev]


### PR DESCRIPTION
Potential fix for [https://github.com/Sir-Thom/thomastoulouse.ca/security/code-scanning/4](https://github.com/Sir-Thom/thomastoulouse.ca/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since this workflow is primarily for running Playwright tests, it only needs read access to the repository contents. We will set `contents: read` as the minimal required permission. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
