### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Jest
 on: push
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/Sir-Thom/thomastoulouse.ca/security/code-scanning/3](https://github.com/Sir-Thom/thomastoulouse.ca/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, installs dependencies, and runs tests, it only needs read access to repository contents. The best way to do this is to add `permissions: { contents: read }` at the top level of the workflow file, just after the `name` and before `on`. This will apply the permission restriction to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
